### PR TITLE
Small edit to help with stack issues

### DIFF
--- a/R/ectotherm.R
+++ b/R/ectotherm.R
@@ -784,7 +784,7 @@ ectotherm <- function(
   ndays <- length(rainfall) # get number of days of simulation
 
   # error trapping
-  if(micro$metout[1,2] != 0){
+  if(metout[1,2] != 0){
     message("error: microclimate input must start at midnight (TIME = 0) - check your microclimate input \n")
     errors<-1
   }


### PR DESCRIPTION
Hi NicheMapR coders!

I am running MNMs for many anuran species across the Southeast United States. I've parallelized my code by creating one function that runs one microclimate model and then has a for loop for an ectotherm model for each species. 
1) Thanks for adding the warning about depths in the micro_* functions. I feel a little proud that my ignorance might help future users. 
2) Because of the structure of the function described above, I need ectotherm to only rely on arguments passed to it. The new error catching message about time-starting causes a stack error now. I appreciate the addition of the warning message; this package has great, clear messages to aid users.  I edited the error-catch added yesterday to rely on the metout argument instead of micro$metout. The changes reflected in the TraciPopejoy/NicheMapR branch fixed the stack error I received. 

 I hope this is an appropriate edit! I appreciate the addition of the warning message; this package has great, clear messages to aid users. 

Thanks for your time and for building a great R package!
Traci