### PR TITLE
patch rainydays divide by 0 error in micro_global()

### DIFF
--- a/R/micro_global.R
+++ b/R/micro_global.R
@@ -912,11 +912,19 @@ micro_global <- function(
             if(k==1){
               RAINFALL1[m]<-RAINFALL[i]*rainfrac*rainmult # if first day of month, make user-specified fraction of monthly rainfall fall on first day
             }else{
-              RAINFALL1[m]<-(RAINFALL[i]*(1-rainfrac)*rainmult)/RAINYDAYS[i] # make remaining rain fall evenly over the remaining number of rainy days for the month, starting at the beginning of the month
+              if(RAINYDAYS[i]>0){
+                RAINFALL1[m]<-(RAINFALL[i]*(1-rainfrac)*rainmult)/RAINYDAYS[i] # make remaining rain fall evenly over the remaining number of rainy days for the month, starting at the beginning of the month
+              }else{
+                RAINFALL1[m]<-0
+              }
             }
           }else{
             if(rainfrac==0){
-              RAINFALL1[m]<-(RAINFALL[i]*rainmult)/RAINYDAYS[i]
+              if(RAINYDAYS[i]>0){
+                RAINFALL1[m]<-(RAINFALL[i]*rainmult)/RAINYDAYS[i]
+              }else{
+                RAINFALL1[m]<-0
+              }
             }else{
               RAINFALL1[m]<-0
             }


### PR DESCRIPTION
proposed patch to issue #22 

I haven't copied this over to micro_global_grid() or micro_terra() where the code is duplicated.

Please also review to make sure it doesn't break the intended use of these functions (I just zeroed out rainfall if no raininy days, but might that mess up totals in some situations?)