### PR TITLE
bug fix and two features added to micro_openmeteo

### DIFF
--- a/R/micro_openmeteo.R
+++ b/R/micro_openmeteo.R
@@ -781,6 +781,8 @@ micro_openmeteo <- function(
           timezone = "auto"
         )
         openmeteo.out <- rbind(openmeteo.out1[, 1:10], openmeteo.out2[, 1:10])
+      } else {
+        openmeteo.out <- openmeteo.out1[, 1:10]
       }
 
       ALTT <- elev

--- a/R/micro_openmeteo.R
+++ b/R/micro_openmeteo.R
@@ -7,6 +7,7 @@
 #' @param dfinish Last day to run, date in format "d/m/Y" e.g. "31/12/2016"
 #' @param fstart First day to leverage archived forecast data, must be after dstart and before dfinish
 #' @param dspinup Number of days to simulate for spin-up
+#' @param forecast_model Supply to specify a model for forecasted values (if NA defaults to autoselection of best model). See Open-Meteo API documentation for list of models: https://github.com/open-meteo/open-data
 #' @param dem A digital elevation model used by microclima for micro-topographic effects, produced by microclima function 'get_dem' via R package 'elevatr' (internally generated via same function based on 'loc' if NA)
 #' @param dem2 A digital elevation model used by microclima for meso-climate calculations, produced by microclima function 'get_dem' via R package 'elevatr' (internally generated via same function based on 'loc' if NA)
 #' @param dem.res Requested resolution of the DEM from elevatr, m
@@ -306,6 +307,7 @@ micro_openmeteo <- function(
     dfinish = format(Sys.time()+3600*24*13, "%d/%m/%Y"),
     fstart = NA,
     dspinup = 365,
+    forecast_model = NA,
     dem = NA,
     dem2 = dem,
     dem.res = 30,
@@ -782,7 +784,7 @@ micro_openmeteo <- function(
                      "soil_moisture_27_81cm"),
           daily = NULL,
           response_units = NULL,
-          model = NULL,
+          model = ifelse(is.na(forecast_model), NULL, forecast_model),
           timezone = "auto"
         )
         openmeteo.out <- rbind(openmeteo.out1[, 1:10], openmeteo.out2[, 1:10])

--- a/R/micro_openmeteo.R
+++ b/R/micro_openmeteo.R
@@ -5,6 +5,7 @@
 #' @param loc Longitude and latitude (decimal degrees) or string for place name search via openmeteo::geocode()
 #' @param dstart First day to run, date in format "d/m/Y" e.g. "01/01/2016"
 #' @param dfinish Last day to run, date in format "d/m/Y" e.g. "31/12/2016"
+#' @param fstart First day to leverage archived forecast data, must be after dstart and before dfinish
 #' @param dspinup Number of days to simulate for spin-up
 #' @param dem A digital elevation model used by microclima for micro-topographic effects, produced by microclima function 'get_dem' via R package 'elevatr' (internally generated via same function based on 'loc' if NA)
 #' @param dem2 A digital elevation model used by microclima for meso-climate calculations, produced by microclima function 'get_dem' via R package 'elevatr' (internally generated via same function based on 'loc' if NA)
@@ -303,6 +304,7 @@ micro_openmeteo <- function(
     loc = c(-5.3, 50.13),
     dstart = format(Sys.time(), "%d/%m/%Y"),
     dfinish = format(Sys.time()+3600*24*13, "%d/%m/%Y"),
+    fstart = NA,
     dspinup = 365,
     dem = NA,
     dem2 = dem,
@@ -566,6 +568,9 @@ micro_openmeteo <- function(
     ystart <- as.numeric(substr(dstart2, 7, 10))
     yfinish <- as.numeric(substr(dfinish, 7, 10))
     yearlist <- seq(ystart, (ystart + (nyears - 1)), 1)
+    if(is.na(fstart)) { # If forecast start date not provided, set as 2 days before present
+      fstart <- as.Date(Sys.time(), format = "%d/%m/%Y") - 2
+    }
 
     ################## time related variables #################################
 
@@ -722,7 +727,7 @@ micro_openmeteo <- function(
           openmeteo.end <- as.Date(dfinish, format = "%d/%m/%Y")
           forecast <- FALSE
         }else{
-          openmeteo.end <- as.Date(dstart, format = "%d/%m/%Y") - 3
+          openmeteo.end <- as.Date(fstart, format = "%d/%m/%Y") - 1
         }
        openmeteo.out1 <- weather_history(
           location = c(loc[2], loc[1]),
@@ -754,7 +759,7 @@ micro_openmeteo <- function(
       if(forecast){
         openmeteo.out2 <- weather_forecast(
           location = c(loc[2], loc[1]),
-          start = as.Date(dstart, format = "%d/%m/%Y")-2,
+          start = as.Date(fstart, format = "%d/%m/%Y"),
           end = as.Date(dfinish, format = "%d/%m/%Y"),
           hourly = c("temperature_2m",
                      "relative_humidity_2m",


### PR DESCRIPTION
Hi Mike,

I have three commits added here, all to micro_openmeteo.R:

1. a small bug fix: if the user's specified dates are in fact no a forecast, still need to populate openmeteo.out from openmeteo1
2. I added a new argument `fstart`, which allows users to take advantage of openmeteo's archived forecasts, and also specify what day they want to use historic weather predictions (which are reanalysis, I think) vs an archived forecast. This is useful for more properly hindcasting (i.e. using forecasted data from the past)
3. I added another argument `forecast_model`, which lets users specify a particular model of choice (see the README [here](https://github.com/open-meteo/open-data) for options, I've added this to function documentation)

I didn't rebuild the package after this, so changes to the function documentation won't be rendered yet. Hope this is of use! I'm going to keep working with this function and may continue to build things out on my end.